### PR TITLE
import cPickle in Python 3

### DIFF
--- a/model.py
+++ b/model.py
@@ -5,7 +5,7 @@ import scipy.io
 import theano
 import theano.tensor as T
 import codecs
-import cPickle
+import _pickle as cPickle
 
 from utils import shared, set_values, get_name
 from nn import HiddenLayer, EmbeddingLayer, DropoutLayer, LSTM, forward


### PR DESCRIPTION
In Python 3.x the method for importing cPickle changed. This issue will fix that. (https://askubuntu.com/questions/742782/how-to-install-cpickle-on-python-3-4#814132)